### PR TITLE
Optimisation finary client

### DIFF
--- a/api.js
+++ b/api.js
@@ -158,10 +158,15 @@ export class FinaryClient {
                         throw new Error('TOKEN_EXPIRE');
                     }
                     if (response.status === 400) {
+                        let errorDetails = "";
+                        try {
+                            errorDetails = await response.text();
+                        } catch (e) {}
                         console.error("❌ HTTP 400 - Bad Request", {
                             endpoint,
                             data: options.body,
-                            context: contextInfo
+                            context: contextInfo,
+                            apiError: errorDetails
                         });
                     }
                     if (response.status === 500 && retryCount < this.MAX_RETRIES) {

--- a/api.js
+++ b/api.js
@@ -126,7 +126,7 @@ export class FinaryClient {
      * @param {Object} [options={}] - Options fetch (méthode, headers, body...).
      * @returns {Promise<any>} La réponse de l'API ou null en cas d'erreur.
      */
-    async apiRequest(endpoint, options = {}) {
+    async apiRequest(endpoint, options = {}, contextInfo = {}) {
         let retryCount = 0;
 
         const executeRequest = async () => {
@@ -156,6 +156,13 @@ export class FinaryClient {
                 if (!response.ok) {
                     if (response.status === 401) {
                         throw new Error('TOKEN_EXPIRE');
+                    }
+                    if (response.status === 400) {
+                        console.error("❌ HTTP 400 - Bad Request", {
+                            endpoint,
+                            data: options.body,
+                            context: contextInfo
+                        });
                     }
                     if (response.status === 500 && retryCount < this.MAX_RETRIES) {
                         retryCount++;
@@ -345,7 +352,7 @@ export class FinaryClient {
         return await this.apiRequest(`/users/me/real_estates/${id}`, {
             method: 'PUT',
             body: JSON.stringify(data)
-        });
+        }, { id, data });
     }
 
     /**

--- a/api.js
+++ b/api.js
@@ -181,7 +181,16 @@ export class FinaryClient {
                         return null;
                     }
                     try {
-                        return JSON.parse(text);
+                        const parsed = JSON.parse(text);
+                        // Ajoute ce log pour afficher le contexte à chaque appel
+                        if (Object.keys(contextInfo).length > 0) {
+                            console.log("✅ API call context:", {
+                                endpoint,
+                                data: options.body,
+                                context: contextInfo
+                            });
+                        }
+                        return parsed;
                     } catch (e) {
                         console.error("❌ JSON parse error:", e);
                         throw new Error(`Invalid JSON response: ${text.substring(0, 100)}...`);

--- a/realt-sync.js
+++ b/realt-sync.js
@@ -92,7 +92,8 @@ export class RealTSync {
 
             // Updates
             console.log('\n--- Starting Updates ---');
-            await Promise.all(combined.toUpdate.map(async (item, idx) => {
+            for (let idx = 0; idx < combined.toUpdate.length; idx++) {
+                const item = combined.toUpdate[idx];
                 try {
                     const progress = Math.round(100 * (idx + 1) / (combined.toUpdate.length || 1));
                     if (progressCallback) progressCallback("update", {
@@ -126,7 +127,7 @@ export class RealTSync {
                             ownership_repartition: [{
                                 share: parseFloat((item.wallet.balance / (item.wallet.realTDetails.totalTokens * finaryCheat))).toFixed(4),
                                 membership_id: membershipId
-                                }],
+                            }],
                             description: `RealT - ${item.wallet.tokenName} (${item.wallet.contractAddress})`
                         }
                     );
@@ -144,7 +145,7 @@ export class RealTSync {
                         log: `Erreur lors de la mise à jour de ${item.wallet.tokenName}: ${error.message}`
                     });
                 }
-            }));
+            };
 
             // Deletions
             console.log('\n--- Starting Deletions ---');

--- a/realt-sync.js
+++ b/realt-sync.js
@@ -125,7 +125,7 @@ export class RealTSync {
                             name: item.wallet.tokenName,
                             user_estimated_value: item.wallet.realTDetails.tokenPrice * item.wallet.realTDetails.totalTokens * finaryCheat,
                             ownership_repartition: [{
-                                share: parseFloat((item.wallet.balance / (item.wallet.realTDetails.totalTokens * finaryCheat))).toFixed(4),
+                                share: parseFloat((item.wallet.balance / (item.wallet.realTDetails.totalTokens * finaryCheat))).toFixed(4)*1,
                                 membership_id: membershipId
                             }],
                             description: `RealT - ${item.wallet.tokenName} (${item.wallet.contractAddress})`
@@ -225,6 +225,9 @@ export class RealTSync {
                         } else if (calulatedOnwership >= 0.0000005) {
                             finaryCheat = 0.01;
                         }  
+                        
+                        const surfaceValue = Number(tokenDetails.squareFeet) * 0.09290304 * finaryCheat;
+                        console.log(surfaceValue, 'm²');
 
                         await this.retryApiCall(async () => {
                             await finaryClient.addRealEstateAsset({
@@ -256,7 +259,7 @@ export class RealTSync {
                                 is_estimable: false,
                                 user_estimated_value: (tokenDetails.tokenPrice * tokenDetails.totalTokens * finaryCheat),
                                 description: `RealT - ${token.tokenName} (${token.contractAddress})`,
-                                surface: tokenDetails.squareFeet * 0.09290304 * finaryCheat, // Convert sq ft to sq m
+                                surface: (surfaceValue && !isNaN(surfaceValue) && surfaceValue > 1) ? surfaceValue : 1, // 1 m² par défaut si problème
                                 agency_fees: "",
                                 notary_fees: "",
                                 furnishing_fees: "",


### PR DESCRIPTION
**But principal :**
 Corriger une erreur API liée à la valeur du champ surface inférieure à 1 lors de la synchronisation RealT → Finary.

**Modifications apportées :**
_Dans api.js :_
Amélioration du log d’erreur HTTP 400 pour inclure le détail de la réponse API (apiError).
_Dans realt-sync.js :_
Lors de l’ajout d’un bien immobilier, la valeur envoyée pour surface est désormais :
surface: (surfaceValue && !isNaN(surfaceValue) && surfaceValue > 1) ? surfaceValue : 1
Cela force la valeur à 1 m² si la surface calculée est absente, invalide ou ≤ 1.
Ajout d’un log pour afficher la surface calculée en m².
Correction du calcul de share pour s’assurer qu’il est bien numérique.

**Effet :**
Les appels API ne provoquent plus d’erreur 400 si la surface est trop petite ou invalide : une valeur par défaut de 1 m² est utilisée.
Les logs d’erreur HTTP 400 sont plus détaillés pour faciliter le debug.